### PR TITLE
rpi0: generate uncompressed image

### DIFF
--- a/repart-pi0.nix
+++ b/repart-pi0.nix
@@ -66,7 +66,7 @@ in
       patches = old.patches or [] ++ [ ./0001-repart-Support-named-GPT-flags-in-libfdisk.patch ];
     });
     name = "image";
-    compression.enable = true;
+    compression.enable = false;
     partitions = {
       "01-esp" = {
         contents = {


### PR DESCRIPTION
## Description

Build was failing off `master`: https://github.com/MatthewCroughan/raspberrypi-nixos-example/commit/a4d2595b0839a7e7f1bc297dc9f006042d1d958d
```
$ nix build .#images.pi0
structuredAttrs is enabled
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
'repart.d' -> '/build/amended-repart.d'
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Building image with systemd-repart...
Pre-populating ext4 filesystem of partition 02-root.conf twice to calculate minimal partition size
Preparing to populate ext4 filesystem.
Ready to populate ext4 filesystem.
mke2fs 1.47.2 (1-Jan-2025)
Discarding device blocks: done
Creating filesystem with 268435456 4k blocks and 67108864 inodes
Filesystem UUID: 3aa1fffd-c3ff-4a31-84e6-f6c53bda652c
Superblock backups stored on blocks:
        32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208,
        4096000, 7962624, 11239424, 20480000, 23887872, 71663616, 78675968,
        102400000, 214990848

Allocating group tables: done
Writing inode tables: done
Creating journal (262144 blocks): done
Copying files into the device: done
Writing superblocks and filesystem accounting information: done

/build/.#repart9a2b027bcb301d0c successfully formatted as ext4 (label "nixos", uuid 3aa1fffd-c3ff-4a31-84e6-f6c53bda652c)
Minimal partition size of ext4 filesystem of partition 02-root.conf is 2.8G
mke2fs 1.47.2 (1-Jan-2025)
Discarding device blocks: done
Creating filesystem with 738576 4k blocks and 184736 inodes
Filesystem UUID: 882b2779-f47b-4876-bca1-c08bb7a7fbbc
Superblock backups stored on blocks:
        32768, 98304, 163840, 229376, 294912

Allocating group tables: done
Writing inode tables: done
Creating journal (16384 blocks): done
Copying files into the device: done
Writing superblocks and filesystem accounting information: done

/build/.#repart9a2b027bcb301d0c successfully formatted as ext4 (label "nixos", uuid 882b2779-f47b-4876-bca1-c08bb7a7fbbc)
Automatically determined minimal disk image size as 3.3G.
Sized 'image.raw' to 3.3G.
Applying changes to image.raw.
Copying in '/build/.#repart9a2b027bcb301d0c' (2.8G) on block level into future partition 1.
Copying in of '/build/.#repart9a2b027bcb301d0c' on block level completed.      G 100%%
Syncing future partition 1 contents to disk.
Block level copying and synchronization of partition 1 complete in 2.393908s (1.1G/s).
Formatting future partition 0.
Preparing to populate vfat filesystem.
Ready to populate vfat filesystem.
mkfs.fat 4.2 (2021-01-31)
/build/repart-6nHBhJ successfully formatted as vfat (label "ESP", uuid 793a442b)
Successfully formatted future partition 0.
Syncing future partition 0 contents to disk.
Adding new partition 0 to partition table.
Adding new partition 1 to partition table.
Writing new partition table.
All done.
[
        {
                "type" : "esp",
                "label" : "ESP",
                "uuid" : "dac4058a-2fc0-4808-a7ef-b8b4501c00ce",
                "partno" : 0,
                "file" : "/build/amended-repart.d/01-esp.conf",
                "node" : "image.raw1",
                "offset" : 1048576,
                "old_size" : 0,
                "raw_size" : 536870912,
                "old_padding" : 0,
                "raw_padding" : 0,
                "activity" : "create"
        },
        {
                "type" : "root-arm",
                "label" : "nixos",
                "uuid" : "454218cd-8d82-46f2-9fa9-7c70ac39ecd3",
                "partno" : 1,
                "file" : "/build/amended-repart.d/02-root.conf",
                "node" : "image.raw2",
                "offset" : 537919488,
                "old_size" : 0,
                "raw_size" : 3025207296,
                "old_padding" : 0,
                "raw_padding" : 0,
                "activity" : "create"
        }
]
buildPhase completed in 1 minutes 21 seconds
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
/nix/store/4da7yx9vqf78hypz6bgdz19j6x2s9gq6-stdenv-linux/setup: line 269: /nix/store/d0kwp7x7rghg6zx197kislngxa5yxwww-gptfdisk-1.0.10/bin/sgdisk: cannot execute: required file not found
```

The above error seems to be due to the sgdisk looking for image.raw and not image.raw.zstd (when compression is enabled): https://github.com/MatthewCroughan/raspberrypi-nixos-example/blob/a4d2595b0839a7e7f1bc297dc9f006042d1d958d/flake.nix#L20 I dont know a good way to make sgdisk manipulate a zstd image so opting to turn off compression.

I believe this effects the pi3 build as well but dont have a pi3 to test with: https://github.com/MatthewCroughan/raspberrypi-nixos-example/blob/a4d2595b0839a7e7f1bc297dc9f006042d1d958d/flake.nix#L14

## Tests

- Confirmed working on rpi0-w